### PR TITLE
Feat: Add BalanceDisplay card to Volatility Trading page

### DIFF
--- a/src/app/volatility-trading/page.tsx
+++ b/src/app/volatility-trading/page.tsx
@@ -480,6 +480,7 @@ export default function VolatilityTradingPage() {
 
   return (
     <div className="container mx-auto py-2 space-y-6">
+      <BalanceDisplay balance={currentBalance} accountType={paperTradingMode} />
       <h1 className="text-3xl font-bold text-foreground flex items-center gap-2"><Activity className="h-8 w-8 text-primary" />AI Volatility Index Trading</h1>
       
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">


### PR DESCRIPTION
Integrates the existing BalanceDisplay component at the top of the Volatility Trading page (`src/app/volatility-trading/page.tsx`).

The component displays your current paper or live (simulated) balance, consistent with its usage on the main dashboard. Data for the balance and account type is sourced from the `useAuth` hook and local page state, which were already available.