### PR TITLE
fix: Improve trade placement reliability and validation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
-import { getCandles, placeTrade, instrumentToDerivSymbol, getTradingDurations, type PlaceTradeResponse, type DerivContractStatusData, getContractStatus, sellContract } from '@/services/deriv';
+import { getCandles, placeTrade, instrumentToDerivSymbol, getTradingDurations, type PlaceTradeResponse, type DerivContractStatusData, getContractStatus, sellContract, getContractOfferings, type DerivContractOffering } from '@/services/deriv';
 import { v4 as uuidv4 } from 'uuid'; 
 import { getInstrumentDecimalPlaces } from '@/lib/utils';
 import { useAuth } from '@/contexts/auth-context';
@@ -60,6 +60,24 @@ function validateTradeParameters(stake: number, balance: number, accountType: 'd
     return "Invalid Stake: Stake amount must be greater than zero.";
   }
   return null;
+}
+
+function parseDurationToSeconds(durationString?: string): number {
+  if (!durationString) return 0;
+  const value = parseInt(durationString);
+  if (isNaN(value)) return 0; // Handle cases where parseInt fails, e.g., "unknown"
+
+  if (durationString.endsWith('s')) return value;
+  if (durationString.endsWith('m')) return value * 60;
+  if (durationString.endsWith('h')) return value * 60 * 60;
+  if (durationString.endsWith('d')) return value * 24 * 60 * 60;
+
+  // Fallback for if unit is missing but it's a number (treat as seconds)
+  // This might be too lenient, adjust if strict format adherence is required
+  if (!isNaN(parseInt(durationString))) return parseInt(durationString);
+
+  console.warn(`[parseDurationToSeconds] Unknown duration format: ${durationString}`);
+  return 0;
 }
 
 /**
@@ -682,52 +700,87 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
         toast({ title: "AI Auto-Trade", description: strategyResult?.overallReasoning || "No optimal trades found.", duration: 7000 });
         setIsAutoTradingActive(false); return;
       }
-      toast({ title: "AI Strategy Generated", description: `AI proposes ${strategyResult.tradesToExecute.length} trades. Executing...`, duration: 5000 });
+      toast({ title: "AI Strategy Generated", description: `AI proposes ${strategyResult.tradesToExecute.length} trades. Validating and Executing...`, duration: 5000 });
 
-      const placedTradesPromises = strategyResult.tradesToExecute.map(async (proposedTrade) => {
+      const newActiveTradesBatch: ActiveAutomatedTrade[] = [];
+
+      for (const proposedTrade of strategyResult.tradesToExecute) {
+        const derivSymbol = instrumentToDerivSymbol(proposedTrade.instrument as InstrumentType);
         try {
-          let tradeDurationValue = proposedTrade.durationSeconds;
-          let tradeDurationUnit: "s" | "m" = 's';
+          logAutomatedTradingEvent(`Validating proposal for ${proposedTrade.instrument} (${derivSymbol}): ${proposedTrade.action}, Stake: $${proposedTrade.stake}, Duration: ${proposedTrade.durationSeconds}s`);
 
-          // Check if instrument is Forex (example check, refine as needed)
-          const isForexInstrument = (proposedTrade.instrument.includes('/') && !proposedTrade.instrument.includes('BTC') && !proposedTrade.instrument.includes('ETH'));
+          const offerings = await getContractOfferings(derivSymbol, currentToken!); // currentToken is checked non-null at start of function
 
-          if (isForexInstrument) {
-            // Deriv often requires longer minimum durations for Forex, e.g., 15 minutes.
-            // If AI proposes a short duration in seconds, convert to minutes and ensure minimum.
-            if (proposedTrade.durationSeconds < 900) { // Less than 15 minutes
-              tradeDurationValue = 15; // Set to a common minimum of 15 minutes
-              tradeDurationUnit = 'm';
-              logAutomatedTradingEvent(`Adjusted ${proposedTrade.instrument} trade duration from ${proposedTrade.durationSeconds}s to 15m due to typical Forex minimums.`);
-            } else if (proposedTrade.durationSeconds % 60 === 0) {
-              // If it's a whole number of minutes, send in minutes
-              tradeDurationValue = proposedTrade.durationSeconds / 60;
-              tradeDurationUnit = 'm';
-            }
-            // else, if it's seconds but >= 900s and not a whole minute, it might still be valid as seconds.
+          if (!offerings || offerings.length === 0) {
+            const validationErrorMsg = `No contract offerings found for ${derivSymbol}. Cannot validate trade.`;
+            logAutomatedTradingEvent(validationErrorMsg);
+            newActiveTradesBatch.push({
+              id: `error_validation_${uuidv4()}`,
+              instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
+              derivSymbol, action: proposedTrade.action, stake: proposedTrade.stake,
+              durationSeconds: proposedTrade.durationSeconds, reasoning: proposedTrade.reasoning,
+              entrySpot: 0, buyPrice: 0, startTime: Date.now(), status: 'error_validation',
+              validationError: validationErrorMsg,
+            } as ActiveAutomatedTrade);
+            continue;
           }
 
-          const tradeDetails: any = { // Using 'any' for TradeDetails as its definition is implicit
-            symbol: instrumentToDerivSymbol(proposedTrade.instrument as InstrumentType),
+          const intradayOffering = offerings.find(o => o.expiry_type === 'intraday' && o.contract_category === 'callput' && o.start_type === 'spot');
+
+          if (!intradayOffering) {
+            const validationErrorMsg = `No suitable 'intraday/callput/spot' offering found for ${derivSymbol}. Cannot validate trade.`;
+            logAutomatedTradingEvent(validationErrorMsg);
+            newActiveTradesBatch.push({
+              id: `error_validation_${uuidv4()}`,
+              instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
+              derivSymbol, action: proposedTrade.action, stake: proposedTrade.stake,
+              durationSeconds: proposedTrade.durationSeconds, reasoning: proposedTrade.reasoning,
+              entrySpot: 0, buyPrice: 0, startTime: Date.now(), status: 'error_validation',
+              validationError: validationErrorMsg,
+            } as ActiveAutomatedTrade);
+            continue;
+          }
+
+          const minDurationSeconds = parseDurationToSeconds(intradayOffering.min_contract_duration);
+          const maxDurationSeconds = parseDurationToSeconds(intradayOffering.max_contract_duration);
+
+          if (proposedTrade.durationSeconds < minDurationSeconds || (maxDurationSeconds > 0 && proposedTrade.durationSeconds > maxDurationSeconds)) {
+            const validationErrorMsg = `Skipping trade for ${proposedTrade.instrument}: Proposed duration ${proposedTrade.durationSeconds}s is outside valid range [${minDurationSeconds}s - ${maxDurationSeconds}s] for intraday offering.`;
+            logAutomatedTradingEvent(validationErrorMsg);
+            newActiveTradesBatch.push({
+              id: `error_validation_${uuidv4()}`,
+              instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
+              derivSymbol, action: proposedTrade.action, stake: proposedTrade.stake,
+              durationSeconds: proposedTrade.durationSeconds, reasoning: proposedTrade.reasoning,
+              entrySpot: 0, buyPrice: 0, startTime: Date.now(), status: 'error_validation',
+              validationError: validationErrorMsg,
+            } as ActiveAutomatedTrade);
+            continue;
+          }
+
+          logAutomatedTradingEvent(`Validation passed for ${proposedTrade.instrument}. Proceeding to place trade.`);
+
+          const tradeDetails: any = { // Using 'any' for TradeDetails as its definition is implicit in deriv.ts
+            symbol: derivSymbol,
             contract_type: proposedTrade.action,
-            duration: tradeDurationValue,
-            duration_unit: tradeDurationUnit,
+            duration: proposedTrade.durationSeconds, // Use AI's proposed duration in seconds
+            duration_unit: 's',                     // Unit is seconds
             amount: proposedTrade.stake,
             currency: "USD",
             basis: "stake",
-            token: currentToken,
+            token: currentToken!, // Checked non-null at function start
           };
-          logAutomatedTradingEvent(`Placing ${proposedTrade.action} on ${proposedTrade.instrument} for $${proposedTrade.stake}, Duration: ${tradeDurationValue}${tradeDurationUnit}`);
-          const tradeResult = await placeTrade(tradeDetails, currentTargetAccountId);
-          logAutomatedTradingEvent(`Trade placed for ${proposedTrade.instrument}: ${proposedTrade.action}, Stake: $${proposedTrade.stake}, Deriv ID: ${tradeResult.contract_id}, Adjusted Duration: ${tradeDurationValue}${tradeDurationUnit}`);
 
-          // RE-FETCH BALANCE AFTER TRADE
+          logAutomatedTradingEvent(`Placing ${proposedTrade.action} on ${proposedTrade.instrument} for $${proposedTrade.stake}, Duration: ${proposedTrade.durationSeconds}s`);
+          const tradeResult = await placeTrade(tradeDetails, currentTargetAccountId!); // Checked non-null at function start
+          logAutomatedTradingEvent(`Trade placed for ${proposedTrade.instrument}: ${proposedTrade.action}, Stake: $${proposedTrade.stake}, Deriv ID: ${tradeResult.contract_id}, Duration: ${proposedTrade.durationSeconds}s`);
+
           if (selectedDerivAccountType && currentTargetAccountId) {
             fetchBalanceForAccount(currentTargetAccountId, selectedDerivAccountType);
           }
 
-          return {
-            id: String(tradeResult.contract_id), // Ensure ID is string
+          newActiveTradesBatch.push({
+            id: String(tradeResult.contract_id),
             instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
             derivSymbol: tradeDetails.symbol,
             action: proposedTrade.action,
@@ -736,30 +789,31 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
             reasoning: proposedTrade.reasoning,
             entrySpot: tradeResult.entry_spot,
             buyPrice: tradeResult.buy_price,
-            startTime: Date.now(), // Or use Deriv's start_time if available and preferred
+            startTime: Date.now(),
             longcode: tradeResult.longcode,
-            status: 'open' as ActiveAutomatedTrade['status'],
+            status: 'open',
             monitoringRetryCount: 0,
-          } as ActiveAutomatedTrade;
-        } catch (error: any) {
-          logAutomatedTradingEvent(`Error placing trade for ${proposedTrade.instrument} ${proposedTrade.action}: ${error.message}`);
-          toast({ title: `Trade Placement Error (${proposedTrade.instrument})`, description: error.message, variant: "destructive" });
-          return {
-            id: `error_${uuidv4()}`,
+          } as ActiveAutomatedTrade);
+
+        } catch (error: any) { // This catch now handles errors from getContractOfferings and placeTrade
+          logAutomatedTradingEvent(`Error processing or placing trade for ${proposedTrade.instrument} ${proposedTrade.action}: ${error.message}`);
+          toast({ title: `Trade Processing Error (${proposedTrade.instrument})`, description: error.message, variant: "destructive" });
+          newActiveTradesBatch.push({
+            id: `error_processing_${uuidv4()}`, // Changed prefix to distinguish from pure placement error
             instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
-            derivSymbol: instrumentToDerivSymbol(proposedTrade.instrument as InstrumentType),
+            derivSymbol,
             action: proposedTrade.action,
             stake: proposedTrade.stake,
             durationSeconds: proposedTrade.durationSeconds,
-            reasoning: proposedTrade.reasoning + " (Placement Error)",
+            reasoning: proposedTrade.reasoning + ` (Processing/Placement Error: ${error.message})`,
             entrySpot: 0, buyPrice: 0, startTime: Date.now(),
-            status: 'error_placement' as ActiveAutomatedTrade['status'],
+            status: 'error_placement', // Keep status as error_placement for UI consistency
             validationError: error.message,
-          } as ActiveAutomatedTrade;
+          } as ActiveAutomatedTrade);
         }
-      });
+      }
 
-      const executedTradesResults = await Promise.all(placedTradesPromises);
+      setActiveAutomatedTrades(newActiveTradesBatch);
       setActiveAutomatedTrades(executedTradesResults);
       if (executedTradesResults.every(t => t.status === 'error_placement')) {
         logAutomatedTradingEvent("All proposed trades failed placement. Stopping session.");

--- a/src/services/deriv.ts
+++ b/src/services/deriv.ts
@@ -68,6 +68,19 @@ export interface Tick {
   time: string;
 }
 
+export interface DerivContractOffering {
+  contract_type?: string;
+  contract_category?: string;
+  market?: string;
+  submarket?: string;
+  underlying_symbol?: string;
+  min_contract_duration?: string;
+  max_contract_duration?: string;
+  expiry_type?: string;
+  start_type?: string;
+  // Add any other fields you might need for validation
+}
+
 /**
  * Maps user-friendly instrument names to Deriv API symbols.
  */
@@ -236,6 +249,123 @@ export async function getCandles(
 
     ws.onclose = (event) => {
       console.log('[DerivService/getCandles] WebSocket connection closed. Code:', event.code, 'Reason:', event.reason);
+    };
+  });
+}
+
+export async function getContractOfferings(instrumentSymbol: string, token?: string): Promise<DerivContractOffering[]> {
+  const ws = new WebSocket(DERIV_API_URL);
+  const timeoutDuration = 10000; // 10 seconds for the operation
+  let operationTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  return new Promise((resolve, reject) => {
+    operationTimeout = setTimeout(() => {
+      console.error('[DerivService/getContractOfferings] Operation timed out for symbol:', instrumentSymbol);
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        ws.close(1000, "Operation timed out");
+      }
+      reject(new Error(`Fetching contract offerings for ${instrumentSymbol} timed out.`));
+    }, timeoutDuration);
+
+    ws.onopen = () => {
+      console.log('[DerivService/getContractOfferings] WebSocket connection opened for symbol:', instrumentSymbol);
+      if (token) {
+        console.log('[DerivService/getContractOfferings] Authorizing for symbol:', instrumentSymbol);
+        console.log('[DerivService/getContractOfferings] Sending authorize request:', JSON.stringify({ authorize: token ? 'TOKEN_PRESENT' : 'TOKEN_ABSENT' }));
+        ws.send(JSON.stringify({ authorize: token }));
+      } else {
+        console.log('[DerivService/getContractOfferings] Sending contracts_for request without prior authorization for symbol:', instrumentSymbol);
+        const contractsForPayload = {
+          contracts_for: instrumentSymbol,
+          currency: "USD",
+          product_type: "basic" // Adjust as needed, "basic" is common for general offerings
+        };
+        console.log('[DerivService/getContractOfferings] Sending contracts_for request:', JSON.stringify(contractsForPayload));
+        ws.send(JSON.stringify(contractsForPayload));
+      }
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const response = JSON.parse(event.data as string);
+        // console.log(`[DerivService/getContractOfferings] Raw response for ${instrumentSymbol}:`, JSON.stringify(response, null, 2)); // Optional: for detailed debugging
+
+        if (response.error) {
+          console.error(`[DerivService/getContractOfferings] API Error for ${instrumentSymbol}:`, response.error);
+          if (operationTimeout) clearTimeout(operationTimeout);
+          ws.close();
+          reject(new Error(response.error.message || `Unknown API error fetching contract offerings for ${instrumentSymbol}.`));
+          return;
+        }
+
+        if (response.msg_type === 'authorize') {
+          if (response.authorize?.loginid) {
+            console.log(`[DerivService/getContractOfferings] Authorization successful for ${instrumentSymbol}. Sending contracts_for request...`);
+            const contractsForPayload = {
+              contracts_for: instrumentSymbol,
+              currency: "USD",
+              product_type: "basic"
+            };
+            console.log('[DerivService/getContractOfferings] Sending contracts_for request after auth:', JSON.stringify(contractsForPayload));
+            ws.send(JSON.stringify(contractsForPayload));
+          } else {
+            console.error(`[DerivService/getContractOfferings] Authorization failed for ${instrumentSymbol}:`, response);
+            if (operationTimeout) clearTimeout(operationTimeout);
+            ws.close();
+            reject(new Error(`Authorization failed for fetching contract offerings for ${instrumentSymbol}.`));
+          }
+        } else if (response.msg_type === 'contracts_for') {
+          if (operationTimeout) clearTimeout(operationTimeout);
+          const offerings: DerivContractOffering[] = [];
+          if (response.contracts_for && Array.isArray(response.contracts_for.available)) {
+            response.contracts_for.available.forEach((contract: any) => {
+              if (contract.contract_category === 'callput' && contract.start_type === 'spot') {
+                offerings.push({
+                  contract_category: contract.contract_category,
+                  market: contract.market,
+                  submarket: contract.submarket,
+                  underlying_symbol: contract.underlying_symbol,
+                  min_contract_duration: contract.min_contract_duration,
+                  max_contract_duration: contract.max_contract_duration,
+                  expiry_type: contract.expiry_type,
+                  start_type: contract.start_type,
+                  // contract_type is often not at this level for general offerings,
+                  // but specific to a trade type within the category.
+                  // If Deriv includes it here, it can be mapped: contract_type: contract.contract_type
+                });
+              }
+            });
+          }
+          if (offerings.length === 0) {
+            console.warn(`[DerivService/getContractOfferings] No suitable 'callput/spot' offerings found for ${instrumentSymbol}.`);
+          } else {
+            console.log(`[DerivService/getContractOfferings] Found ${offerings.length} offerings for ${instrumentSymbol}.`);
+          }
+          resolve(offerings);
+          ws.close();
+        }
+      } catch (e: any) {
+        console.error(`[DerivService/getContractOfferings] Error processing message for ${instrumentSymbol}:`, e);
+        if (operationTimeout) clearTimeout(operationTimeout);
+        ws.close();
+        reject(e instanceof Error ? e : new Error(`Failed to process message for contract offerings for ${instrumentSymbol}.`));
+      }
+    };
+
+    ws.onerror = (event) => {
+      let errorMessage = `WebSocket error fetching contract offerings for ${instrumentSymbol}.`;
+      // Basic error event logging, could be expanded if specific Event types are expected
+      console.error(`[DerivService/getContractOfferings] WebSocket Error Event for ${instrumentSymbol}:`, event);
+      if (operationTimeout) clearTimeout(operationTimeout);
+      ws.close();
+      reject(new Error(errorMessage));
+    };
+
+    ws.onclose = (event) => {
+      console.log(`[DerivService/getContractOfferings] WebSocket connection closed for ${instrumentSymbol}. Code: ${event.code}, Reason: ${event.reason}`);
+      if (operationTimeout) clearTimeout(operationTimeout); // Ensure timeout is cleared on close
+      // If promise hasn't settled, it might mean an unexpected close.
+      // Consider rejecting if not already resolved/rejected, though timeout should handle most cases.
     };
   });
 }
@@ -1072,6 +1202,7 @@ export async function placeTrade(tradeDetails: TradeDetails, accountId: string):
   let operationTimeout: ReturnType<typeof setTimeout> | null = null;
   let proposalId: string | null = null;
   let entrySpot: number | null = null;
+  let proposalSubscriptionId: string | null = null; // Added this line
   const startTime = Date.now();
   const timeoutDuration = 18000; // 18 seconds, slightly increased for account switching
 
@@ -1108,9 +1239,16 @@ export async function placeTrade(tradeDetails: TradeDetails, accountId: string):
         // console.log(`[DerivService/placeTrade] Raw response for ${accountId}:`, JSON.stringify(response, null, 2));
 
         if (response.error) {
-          console.error(`[DerivService/placeTrade] Full error response from Deriv:`, JSON.stringify(response, null, 2)); // Added this line
+          console.error(`[DerivService/placeTrade] Full error response from Deriv:`, JSON.stringify(response, null, 2));
           cleanupAndLog(`API Error: ${response.error.message}`, true);
-          reject(new Error(response.error.message || `Unknown API error during trade placement for account ${accountId}.`));
+
+          // If this error is related to a 'buy' attempt OR a 'proposal' attempt, and we have a subscription ID, forget it.
+          if ((response.echo_req?.buy || response.echo_req?.proposal === 1) && proposalSubscriptionId) {
+            console.log(`[DerivService/placeTrade] Forgetting subscription ${proposalSubscriptionId} due to error: ${response.error.message}`);
+            if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ forget: proposalSubscriptionId })); // Check ws state
+            proposalSubscriptionId = null;
+          }
+          reject(new Error(response.error.message || `Deriv API error for account ${accountId}.`));
           return;
         }
 
@@ -1155,23 +1293,38 @@ export async function placeTrade(tradeDetails: TradeDetails, accountId: string):
             return;
           }
         } else if (response.msg_type === 'proposal') {
+          if (response.error) {
+              console.error(`[DerivService/placeTrade] Full error response on proposal (msg_type: proposal):`, JSON.stringify(response, null, 2));
+              cleanupAndLog(`API Error on proposal: ${response.error.message}`, true);
+              if (response.subscription && response.subscription.id) {
+                  console.log('[DerivService/placeTrade] Attempting to forget subscription from erroring proposal:', response.subscription.id);
+                  if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ forget: response.subscription.id }));
+              }
+              reject(new Error(response.error.message || `Proposal API error for account ${accountId}.`));
+              return;
+          }
+
           if (response.proposal && response.proposal.id && response.proposal.spot) {
-            proposalId = response.proposal.id; // proposalId is a variable in placeTrade scope
+            proposalId = response.proposal.id;
             entrySpot = response.proposal.spot;
             console.log(`[DerivService/placeTrade] Proposal received for account ${accountId}. ID: ${proposalId}, Entry Spot: ${entrySpot}. Buying contract...`);
 
             if (response.subscription && response.subscription.id) {
-              console.log('[DerivService/placeTrade] Sending forget request for subscription:', JSON.stringify({ forget: response.subscription.id }));
-              ws!.send(JSON.stringify({ forget: response.subscription.id }));
+              proposalSubscriptionId = response.subscription.id; // Store it
+              console.log(`[DerivService/placeTrade] Stored proposal subscription ID: ${proposalSubscriptionId}`);
             }
 
             const buyRequest = { buy: proposalId, price: tradeDetails.amount };
-            // This console.log was already present, but I'm ensuring it's exactly as requested by the prompt, which it is.
-            console.log(`[DerivService/placeTrade] Sending buy request for account ${accountId}:`, buyRequest);
+            console.log(`[DerivService/placeTrade] Sending buy request for account ${accountId}:`, JSON.stringify(buyRequest));
             ws!.send(JSON.stringify(buyRequest));
           } else {
-            cleanupAndLog(`Invalid proposal response for account ${accountId}: ${JSON.stringify(response)}`, true);
-            reject(new Error(`Invalid proposal response received from Deriv API for account ${accountId}.`));
+            // Invalid proposal response structure
+            cleanupAndLog(`Invalid proposal response structure for account ${accountId}: ${JSON.stringify(response)}`, true);
+            if (response.subscription && response.subscription.id) {
+                console.log('[DerivService/placeTrade] Attempting to forget subscription from malformed proposal:', response.subscription.id);
+                if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ forget: response.subscription.id }));
+            }
+            reject(new Error(`Invalid proposal response structure received for account ${accountId}.`));
           }
         } else if (response.msg_type === 'buy') {
           if (response.buy && response.buy.contract_id) {
@@ -1183,8 +1336,13 @@ export async function placeTrade(tradeDetails: TradeDetails, accountId: string):
               entry_spot: entrySpot!,
             });
           } else {
-            cleanupAndLog(`Buy contract error on account ${accountId}: ${JSON.stringify(response)}`, true);
-            reject(new Error(response.error?.message || `Failed to buy contract on account ${accountId}.`));
+            cleanupAndLog(`Malformed buy success response on account ${accountId}: ${JSON.stringify(response)}`, true);
+            reject(new Error(`Failed to buy contract due to malformed success response on account ${accountId}.`));
+          }
+          if (proposalSubscriptionId) {
+            console.log(`[DerivService/placeTrade] Forgetting subscription ${proposalSubscriptionId} after buy attempt.`);
+            if (ws && ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ forget: proposalSubscriptionId }));
+            proposalSubscriptionId = null;
           }
         } else {
           console.log(`[DerivService/placeTrade] Received other message type for ${accountId}: ${response.msg_type}`, response);


### PR DESCRIPTION
This commit introduces two key improvements to Deriv API interactions:

1.  **`src/services/deriv.ts` - Corrected `forget` Call Timing in `placeTrade`:**
    *   Modified `placeTrade` so that proposal subscriptions are forgotten only *after* a `buy` attempt (success or failure) or if the proposal/buy sequence errors critically. This resolves potential "Unknown contract proposal" errors caused by premature `forget` calls.
    *   A `proposalSubscriptionId` variable is now used to manage the lifecycle of the subscription.

2.  **`src/services/deriv.ts` - Added `getContractOfferings` Function:**
    *   Introduced a new `DerivContractOffering` interface.
    *   Implemented `getContractOfferings` to fetch detailed contract availability information (min/max duration, expiry types, etc.) from the `contracts_for` Deriv API endpoint, specifically filtering for 'callput/spot' type offerings.

3.  **`src/app/page.tsx` - Enhanced Validation in `startAutomatedTradingSession`:**
    *   Imported and now uses `getContractOfferings` to validate each AI-proposed trade.
    *   Before attempting `placeTrade`, it checks if the proposed instrument, contract type (CALL/PUT), and duration (in seconds) are valid against the offerings returned by `getContractOfferings` for 'intraday' contracts.
    *   If a proposal is invalid (e.g., duration out of range, no suitable offering), the trade is skipped, an error is logged, and an `ActiveAutomatedTrade` entry with `status: 'error_validation'` is created for UI feedback.
    *   The previous heuristic logic for adjusting Forex trade durations has been removed in favor of this more precise validation.
    *   Added a `parseDurationToSeconds` helper function for converting duration strings.

These changes aim to significantly reduce errors during automated trade placement by ensuring proposals are valid against actual Deriv offerings and by managing proposal subscriptions correctly.