### PR TITLE
Fix: Correct Handlebars join helper issue in AI prompt

### DIFF
--- a/src/ai/flows/automated-trading-strategy-flow.ts
+++ b/src/ai/flows/automated-trading-strategy-flow.ts
@@ -83,7 +83,7 @@ Available Trade Offerings by Instrument (IMPORTANT!):
   For Instrument: {{@key}}
     {{#if this.rise_fall}}
     - Trade Type: Rise/Fall (CALL/PUT)
-      Available Durations: {{#if this.rise_fall.length}}{{join this.rise_fall ", "}}{{else}}None specified{{/if}}
+      Available Durations: {{#if this.rise_fall.length}}{{#each this.rise_fall}}{{{this}}}{{#unless @last}}, {{/unless}}{{/each}}{{else}}None specified{{/if}}
     {{else}}
     - No Rise/Fall trade type specified for this instrument in the offerings.
     {{/if}}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -847,7 +847,7 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
             if (symGroup.symbol && Array.isArray(symGroup.symbol) && symGroup.symbol.find(s => s && s.name === derivSymbol)) {
               symbolMarketOfferings = symGroup;
               break;
-            } else if (symGroup.symbol && !Array.isArray(symGroup.symbol) && (symGroup.symbol as any)?.name === derivSymbol) {
+            } else if (symGroup.symbol && !Array.isArray(symGroup.symbol) && (symGroup.symbol as any).name === derivSymbol) {
               symbolMarketOfferings = symGroup;
               break;
             }


### PR DESCRIPTION
I replaced the `join` Handlebars helper with an `each` block in the AI prompt string within `src/ai/flows/automated-trading-strategy-flow.ts`. This resolves the Vercel build error "Error: You specified knownHelpersOnly, but used the unknown helper join" by using a standard Handlebars helper for iterating through available durations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the display logic for available durations in the "Rise/Fall" trade type, ensuring clearer formatting in the "Available Trade Offerings by Instrument" section.
  - Updated symbol matching logic for market offerings to enhance reliability when identifying symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->