### PR TITLE
Fix: Enhance instrumentToDerivSymbol to handle direct Deriv symbols

### DIFF
--- a/src/services/deriv.ts
+++ b/src/services/deriv.ts
@@ -134,6 +134,24 @@ export interface GetGlobalTradingDurationsApiResponse { // Top-level API respons
  * Maps user-friendly instrument names to Deriv API symbols.
  */
 export const instrumentToDerivSymbol = (instrument: InstrumentType): string => {
+  const knownDerivSymbolPatterns = [
+    /^frx[A-Z]+$/,    // Forex, e.g., frxEURUSD
+    /^cry[A-Z]+$/,    // Crypto, e.g., cryBTCUSD
+    /^R_\d+$/,        // Volatility Indices (old), e.g., R_100
+    /^1HZ\d+V?$/,     // 1HZ Volatility Indices, e.g., 1HZ10V, 1HZ100V
+    /^stpRNG\d*$/,    // Step Indices, e.g., stpRNG, stpRNG2
+    /^(BOOM|CRASH)\d+N?$/, // Boom/Crash Indices, e.g., BOOM500, CRASH300N
+    /^JD\d+$/,         // Jump Indices, e.g., JD10
+    /^OTC_[A-Z0-9]+$/, // OTC Stock Indices, e.g., OTC_NDX
+    /^WLD[A-Z]+$/      // Basket Indices, e.g., WLDAUD
+  ];
+
+  for (const pattern of knownDerivSymbolPatterns) {
+    if (pattern.test(instrument)) {
+      return instrument; // Input is already a Deriv symbol
+    }
+  }
+
   switch (instrument) {
     case 'EUR/USD':
       return 'frxEURUSD';


### PR DESCRIPTION
The `instrumentToDerivSymbol` function in `src/services/deriv.ts` has been updated to be more robust. It now includes an initial check to determine if the input `instrument` string already matches a known Deriv API symbol pattern (e.g., 'frxEURUSD', 'cryBTCUSD', 'R_100', etc.).

If the input is identified as a direct Deriv symbol, it is returned immediately. Otherwise, the function proceeds to the existing switch-case logic to map user-friendly names (e.g., 'EUR/USD') to their corresponding Deriv symbols.

This prevents the function from incorrectly defaulting to 'R_100' when it receives a valid Deriv symbol that isn't one of the user-friendly names in its switch statement, thereby resolving issues observed during AI trade proposal validation where Deriv symbols were being passed to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of valid Deriv symbols, ensuring that known instrument formats are correctly identified without unnecessary remapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->