### PR TITLE
I've made some changes to prevent a `TypeError` that was occurring wh…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -999,11 +999,19 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
               id: `error_validation_${uuidv4()}`,
               instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
               derivSymbol, action: proposedTrade.action, stake: proposedTrade.stake,
-              durationSeconds: 0, // Or handle differently, as durationString is the source
+              durationSeconds: 0,
               durationString: proposedTrade.durationString,
               reasoning: proposedTrade.reasoning,
-              entrySpot: 0, buyPrice: 0, startTime: Date.now(), status: 'error_validation',
+              entrySpot: 0,
+              buyPrice: 0,
+              startTime: Date.now(),
+              status: 'error_validation',
               validationError: validationMessage,
+              stopLossPrice: 0, // For error entries
+              currentPrice: undefined,
+              currentProfitLoss: undefined,
+              sellPrice: undefined,
+              finalProfitLoss: undefined,
             } as ActiveAutomatedTrade);
             continue;
           }
@@ -1016,11 +1024,19 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
               id: `error_parsing_duration_${uuidv4()}`,
               instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
               derivSymbol, action: proposedTrade.action, stake: proposedTrade.stake,
-              durationSeconds: 0, // Or handle differently
+              durationSeconds: 0,
               durationString: proposedTrade.durationString,
               reasoning: proposedTrade.reasoning + ` (Error: Invalid duration string format from AI: ${proposedTrade.durationString})`,
-              entrySpot: 0, buyPrice: 0, startTime: Date.now(), status: 'error_validation',
+              entrySpot: 0,
+              buyPrice: 0,
+              startTime: Date.now(),
+              status: 'error_validation',
               validationError: `Invalid duration string format from AI: ${proposedTrade.durationString}`,
+              stopLossPrice: 0, // For error entries
+              currentPrice: undefined,
+              currentProfitLoss: undefined,
+              sellPrice: undefined,
+              finalProfitLoss: undefined,
             } as ActiveAutomatedTrade);
             continue;
           }
@@ -1054,22 +1070,27 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
             derivSymbol: tradeDetails.symbol,
             action: proposedTrade.action,
             stake: proposedTrade.stake,
-            durationSeconds: parseDurationToSeconds(proposedTrade.durationString), // Store the second equivalent for internal use if needed
-            durationString: proposedTrade.durationString, // Keep original string
+            durationSeconds: parseDurationToSeconds(proposedTrade.durationString),
+            durationString: proposedTrade.durationString,
             reasoning: proposedTrade.reasoning,
-            entrySpot: tradeResult.entry_spot,
+            entrySpot: tradeResult.entry_spot, // Assigned from tradeResult
             buyPrice: tradeResult.buy_price,
+            stopLossPrice: proposedTrade.action === 'CALL' ? tradeResult.entry_spot * (1 - (selectedStopLossPercentage / 100)) : tradeResult.entry_spot * (1 + (selectedStopLossPercentage / 100)),
             startTime: Date.now(),
             longcode: tradeResult.longcode,
             status: 'open',
             monitoringRetryCount: 0,
+            currentPrice: undefined,
+            currentProfitLoss: undefined,
+            sellPrice: undefined,
+            finalProfitLoss: undefined,
           } as ActiveAutomatedTrade);
 
         } catch (error: any) { // This catch now handles errors from getContractOfferings and placeTrade
           logAutomatedTradingEvent(`Error processing or placing trade for ${proposedTrade.instrument} ${proposedTrade.action}: ${error.message}`);
           toast({ title: `Trade Processing Error (${proposedTrade.instrument})`, description: error.message, variant: "destructive" });
           newActiveTradesBatch.push({
-            id: `error_processing_${uuidv4()}`, // Changed prefix to distinguish from pure placement error
+            id: `error_processing_${uuidv4()}`,
             instrument: proposedTrade.instrument as ForexCryptoCommodityInstrumentType,
             derivSymbol,
             action: proposedTrade.action,
@@ -1077,9 +1098,16 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
             durationSeconds: parseDurationToSeconds(proposedTrade.durationString),
             durationString: proposedTrade.durationString,
             reasoning: proposedTrade.reasoning + ` (Processing/Placement Error: ${error.message})`,
-            entrySpot: 0, buyPrice: 0, startTime: Date.now(),
+            entrySpot: 0, // Error entry
+            buyPrice: 0,
+            startTime: Date.now(),
             status: 'error_placement',
             validationError: error.message,
+            stopLossPrice: 0, // Error entry
+            currentPrice: undefined,
+            currentProfitLoss: undefined,
+            sellPrice: undefined,
+            finalProfitLoss: undefined,
           } as ActiveAutomatedTrade);
         }
       }
@@ -1363,18 +1391,18 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
                             {trade.action}
                           </Badge>
                         </TableCell>
-                        <TableCell>${trade.stake.toFixed(2)}</TableCell>
-                        <TableCell>{trade.entryPrice.toFixed(getInstrumentDecimalPlaces(trade.instrument))}</TableCell>
+                        <TableCell>${trade.stake?.toFixed(2) ?? '0.00'}</TableCell>
+                        <TableCell>{trade.entrySpot?.toFixed(getInstrumentDecimalPlaces(trade.instrument)) ?? '-'}</TableCell>
                         <TableCell>{trade.currentPrice?.toFixed(getInstrumentDecimalPlaces(trade.instrument)) ?? '-'}</TableCell>
-                        <TableCell>{trade.stopLossPrice.toFixed(getInstrumentDecimalPlaces(trade.instrument))}</TableCell>
+                        <TableCell>{trade.stopLossPrice?.toFixed(getInstrumentDecimalPlaces(trade.instrument)) ?? '-'}</TableCell>
                         <TableCell>
                            <Badge variant={trade.status === 'active' ? 'secondary' : (trade.status === 'won' ? 'default' : 'destructive')}
                                   className={trade.status === 'active' ? 'bg-blue-500 text-white' : (trade.status === 'won' ? 'bg-green-500 hover:bg-green-600' : 'bg-red-500 hover:bg-red-600')}>
                             {trade.status}
                            </Badge>
                         </TableCell>
-                        <TableCell className={trade.pnl && trade.pnl > 0 ? 'text-green-500' : trade.pnl && trade.pnl < 0 ? 'text-red-500' : ''}>
-                          {trade.pnl ? `$${trade.pnl.toFixed(2)}` : '-'}
+                        <TableCell className={(trade.isSettled ? trade.finalProfitLoss : trade.currentProfitLoss) !== undefined && (trade.isSettled ? trade.finalProfitLoss : trade.currentProfitLoss)! > 0 ? 'text-green-500' : (trade.isSettled ? trade.finalProfitLoss : trade.currentProfitLoss) !== undefined && (trade.isSettled ? trade.finalProfitLoss : trade.currentProfitLoss)! < 0 ? 'text-red-500' : ''}>
+                          { (trade.isSettled ? trade.finalProfitLoss : trade.currentProfitLoss) !== undefined ? `$${(trade.isSettled ? trade.finalProfitLoss! : trade.currentProfitLoss!).toFixed(2)}` : '-' }
                         </TableCell>
                       </TableRow>
                     ))}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,6 +89,7 @@ export interface ActiveAutomatedTrade { // For binary options auto-trading
   currentProfitLossPercentage?: number;
   isValidToSell?: boolean;
   sellPrice?: number;
+  stopLossPrice?: number; // Ensure this is present
 
   // Settlement Fields
   exitTime?: number;


### PR DESCRIPTION
…en displaying the active trades table.

Specifically, this error, `TypeError: Cannot read properties of undefined (reading 'toFixed')`, was happening in `src/app/page.tsx`.

Here's what I did:
- In `src/types/index.ts`, I made sure the `ActiveAutomatedTrade` interface now includes `stopLossPrice?: number;`.
- In `src/app/page.tsx`:
  - Within the `startAutomatedTradingSession` function:
    - When new `ActiveAutomatedTrade` objects are created (for both successful trades and when errors occur), `entrySpot` is now consistently used, and `stopLossPrice` is calculated and assigned.
    - For new trades, fields like `currentPrice` and `currentProfitLoss` are initialized as `undefined`.
  - In the part of the code that renders the active trades table:
    - I corrected `trade.entryPrice` to be `trade.entrySpot`.
    - I added checks (like `?.toFixed(...) ?? '-'`) for `entrySpot`, `stopLossPrice`, `currentPrice`, and the profit/loss fields to ensure they can handle situations where these values might be undefined before trying to format them.
    - I improved how profit/loss is displayed so it correctly uses `finalProfitLoss` for trades that have finished and `currentProfitLoss` for trades that are still open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stop loss price tracking for automated trades, visible in the trade details.
- **Bug Fixes**
  - Improved display of trade financials in the UI, ensuring stake, entry price, and stop loss price are always shown with fallback values to prevent display errors.
  - Enhanced profit/loss display to accurately reflect current or final values with appropriate styling for gains and losses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->