### PR TITLE
Fix: Use 'underlying_symbol' for trading_times request

### DIFF
--- a/src/services/deriv.ts
+++ b/src/services/deriv.ts
@@ -384,7 +384,7 @@ export async function getTradingTimes(instrumentSymbol: string, date: string = '
         // The trading_times request will be sent upon successful authorization
       } else {
         console.log(`[DerivService/getTradingTimes] Sending trading_times request (req_id: ${req_id}) without prior auth for symbol: ${instrumentSymbol}`);
-        ws!.send(JSON.stringify({ trading_times: date, symbol: instrumentSymbol, req_id: req_id }));
+        ws!.send(JSON.stringify({ trading_times: date, underlying_symbol: instrumentSymbol, req_id: req_id }));
       }
     };
 
@@ -406,7 +406,7 @@ export async function getTradingTimes(instrumentSymbol: string, date: string = '
           if (authReqId && response.req_id === authReqId) { // Check if this is the response to our specific auth request
             if (response.authorize) {
               console.log(`[DerivService/getTradingTimes] Authorization successful (authReqId: ${authReqId}) for symbol: ${instrumentSymbol}. Now sending trading_times request (req_id: ${req_id}).`);
-              ws!.send(JSON.stringify({ trading_times: date, symbol: instrumentSymbol, req_id: req_id }));
+              ws!.send(JSON.stringify({ trading_times: date, underlying_symbol: instrumentSymbol, req_id: req_id }));
             } else {
               const authFailedMsg = `Authorization failed in getTradingTimes (authReqId: ${authReqId}) for ${instrumentSymbol}.`;
               cleanupAndLog(authFailedMsg, true);


### PR DESCRIPTION
I corrected the `getTradingTimes` function in `src/services/deriv.ts` to use the `underlying_symbol` parameter instead of `symbol` when sending the `trading_times` request to the Deriv API.

This change addresses the API error "Input validation failed: Properties not allowed: symbol" and ensures the request adheres to the expected parameter name for fetching trading times for a specific instrument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with trading times requests by updating the payload key from "symbol" to "underlying_symbol" when communicating with the Deriv API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->