### PR TITLE
Fix: Resolve multiple data fetches, demo account sync, and default ac…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -207,7 +207,7 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
 
   useEffect(() => {
     const demoToken = userInfo?.derivDemoApiToken;
-    if (demoToken && derivDemoAccountId) {
+    if (selectedDerivAccountType === 'demo' && demoToken && derivDemoAccountId) {
       if (demoBalanceListenerRef.current) {
         demoBalanceListenerRef.current.close();
       }
@@ -219,45 +219,47 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
         derivDemoAccountId,
         (balanceData) => {
           setFreshDemoBalance(balanceData.balance);
-          // setIsLoadingDemoBalance(false); // Status change will handle this
         },
         (error) => {
           console.error('[DashboardPage] Demo Balance Listener Error:', error);
-          // Toast is now handled by onStatusChange for 'error'
         },
-        (status, message) => { // onStatusChange callback
+        (status, message) => {
           setDemoSyncStatus(status);
           if (message) console.log(`[DashboardPage] Demo Listener Status: ${status} - ${message}`);
           if (status === 'error' && message) {
             toast({ title: 'Demo Balance Sync Issue', description: message, variant: 'destructive'});
           }
-          // Manage loading state based on status
           if (status === 'connected' || status === 'error' || status === 'disconnected' || status === 'idle') {
             setIsLoadingDemoBalance(false);
           } else {
             setIsLoadingDemoBalance(true);
           }
         },
-        (closeEvent) => { // onClose callback
+        (closeEvent) => {
           console.log(`[DashboardPage] Demo Balance Listener Closed. Code: ${closeEvent.code}, Clean: ${closeEvent.wasClean}`);
-          // if (!closeEvent.wasClean) setIsLoadingDemoBalance(false); // Covered by onStatusChange
         }
       );
     } else {
        if (demoBalanceListenerRef.current) {
           demoBalanceListenerRef.current.close();
           demoBalanceListenerRef.current = null;
+          console.log('[DashboardPage] Demo Balance Listener explicitly closed due to account type mismatch or missing token/ID.');
        }
-       setFreshDemoBalance(derivDemoBalance ?? DEFAULT_PAPER_BALANCE); // Fallback if no token/ID
+       setFreshDemoBalance(derivDemoBalance ?? DEFAULT_PAPER_BALANCE);
        setIsLoadingDemoBalance(false);
+       setDemoSyncStatus('idle');
     }
-    // This effect's cleanup is implicitly handled by the next run creating a new listener and closing the old one,
-    // and the main unmount cleanup.
-  }, [userInfo?.derivDemoApiToken, derivDemoAccountId, toast, derivDemoBalance, userInfo?.derivAccessToken]); // Added userInfo.derivDemoApiToken
+    return () => {
+      if (demoBalanceListenerRef.current) {
+        demoBalanceListenerRef.current.close();
+        demoBalanceListenerRef.current = null;
+      }
+    };
+  }, [userInfo?.derivDemoApiToken, derivDemoAccountId, toast, derivDemoBalance, selectedDerivAccountType, userInfo?.derivAccessToken]);
 
   useEffect(() => {
     const realToken = userInfo?.derivRealApiToken;
-    if (realToken && derivRealAccountId) {
+    if (selectedDerivAccountType === 'real' && realToken && derivRealAccountId) {
       if (realBalanceListenerRef.current) {
         realBalanceListenerRef.current.close();
       }
@@ -269,13 +271,11 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
         derivRealAccountId,
         (balanceData) => {
           setFreshRealBalance(balanceData.balance);
-          // setIsLoadingRealBalance(false);
         },
         (error) => {
           console.error('[DashboardPage] Real Balance Listener Error:', error);
-          // Toast handled by onStatusChange
         },
-        (status, message) => { // onStatusChange callback
+        (status, message) => {
           setRealSyncStatus(status);
           if (message) console.log(`[DashboardPage] Real Listener Status: ${status} - ${message}`);
           if (status === 'error' && message) {
@@ -287,20 +287,27 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
             setIsLoadingRealBalance(true);
           }
         },
-        (closeEvent) => { // onClose callback
+        (closeEvent) => {
           console.log(`[DashboardPage] Real Balance Listener Closed. Code: ${closeEvent.code}, Clean: ${closeEvent.wasClean}`);
-          // if (!closeEvent.wasClean) setIsLoadingRealBalance(false); // Covered by onStatusChange
         }
       );
     } else {
       if (realBalanceListenerRef.current) {
           realBalanceListenerRef.current.close();
           realBalanceListenerRef.current = null;
+          console.log('[DashboardPage] Real Balance Listener explicitly closed due to account type mismatch or missing token/ID.');
       }
-      setFreshRealBalance(derivLiveBalance ?? DEFAULT_LIVE_BALANCE); // Fallback
+      setFreshRealBalance(derivLiveBalance ?? DEFAULT_LIVE_BALANCE);
       setIsLoadingRealBalance(false);
+      setRealSyncStatus('idle');
     }
-  }, [userInfo?.derivRealApiToken, derivRealAccountId, toast, derivLiveBalance, userInfo?.derivAccessToken]); // Added userInfo.derivRealApiToken
+    return () => {
+      if (realBalanceListenerRef.current) {
+        realBalanceListenerRef.current.close();
+        realBalanceListenerRef.current = null;
+      }
+    };
+  }, [userInfo?.derivRealApiToken, derivRealAccountId, toast, derivLiveBalance, selectedDerivAccountType, userInfo?.derivAccessToken]);
 
   const fetchBalanceForAccount = useCallback(async (accountId: string, type: 'demo' | 'real') => {
     // This function relies on a backend API. Ensure the backend uses the correct token for the given accountId.
@@ -373,62 +380,77 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
   // DerivBalanceListener handles initial and subsequent updates.
 
   useEffect(() => {
-    const fetchGlobalData = async () => {
-      if (!userInfo) {
-        return;
-      }
-
+    const fetchInitialGlobalData = async () => {
       let currentToken: string | undefined | null = null;
-      if (selectedDerivAccountType === 'demo' && userInfo.derivDemoApiToken) {
-        currentToken = userInfo.derivDemoApiToken;
-      } else if (selectedDerivAccountType === 'real' && userInfo.derivRealApiToken) {
-        currentToken = userInfo.derivRealApiToken;
-      } else {
-        currentToken = userInfo.derivDemoApiToken || userInfo.derivRealApiToken || userInfo.derivAccessToken;
+      if (userInfo) {
+        if (selectedDerivAccountType === 'demo' && userInfo.derivDemoApiToken) {
+          currentToken = userInfo.derivDemoApiToken;
+        } else if (selectedDerivAccountType === 'real' && userInfo.derivRealApiToken) {
+          currentToken = userInfo.derivRealApiToken;
+        } else {
+          currentToken = userInfo.derivAccessToken;
+        }
       }
 
       // Fetch Global Offerings
-      if (!globalOfferingsData && !isLoadingGlobalOfferings) {
-        console.log(`[DashboardPage] Fetching global trading offerings... (Using token for ${selectedDerivAccountType || 'default account'})`);
+      if (userInfo && !globalOfferingsData && !isLoadingGlobalOfferings) {
         setIsLoadingGlobalOfferings(true);
-        setGlobalOfferingsError(null);
+        setGlobalOfferingsError(null); // Clear previous errors
+        logAutomatedTradingEvent('Fetching global trading offerings...');
         try {
-          const offeringsData = await getGlobalTradingOfferings(currentToken);
-          if (offeringsData) {
+          // Use currentToken or undefined if null, as getGlobalTradingOfferings might expect string | undefined
+          const offeringsData = await getGlobalTradingOfferings(currentToken || undefined);
+          if (offeringsData && !offeringsData.error) {
             setGlobalOfferingsData(offeringsData);
-            console.log("[DashboardPage] Global trading offerings fetched successfully.");
+            logAutomatedTradingEvent("[DashboardPage] Global trading offerings fetched and cached successfully.");
           } else {
-            throw new Error("Received null or empty global offerings data.");
+            const errorMsg = offeringsData?.error || 'Failed to fetch global offerings (empty response).';
+            setGlobalOfferingsError(errorMsg);
+            setGlobalOfferingsData(null);
+            logAutomatedTradingEvent(`[DashboardPage] Error fetching global trading offerings: ${errorMsg}`);
+            // toast({ title: "Offerings Load Error", description: errorMsg, variant: "destructive" }); // Optionally toast here or rely on other UI
           }
-        } catch (error: any) {
-          console.error("[DashboardPage] Error fetching global trading offerings:", error);
-          setGlobalOfferingsError(error.message || "Failed to load global trading offerings.");
-          toast({ title: "Offerings Load Error", description: `Failed to load global offerings: ${error.message}`, variant: "destructive" });
+        } catch (err: any) {
+          const errorMsg = err.message || 'Exception while fetching global offerings.';
+          setGlobalOfferingsError(errorMsg);
           setGlobalOfferingsData(null);
+          logAutomatedTradingEvent(`[DashboardPage] Error fetching global trading offerings: ${errorMsg}`);
+          // toast({ title: "Offerings Load Error", description: errorMsg, variant: "destructive" }); // Optionally toast here
         } finally {
           setIsLoadingGlobalOfferings(false);
         }
       }
 
-      // Fetch All Trading Times
-      if (!allTradingTimesData && !isLoadingAllTradingTimes && currentToken) { // Ensure token is available
-        logAutomatedTradingEvent("Fetching all trading times data...");
+      // Fetch All Trading Times - TARGET SECTION FOR FIXING MULTIPLE TRADING TIMES FETCH
+      if (currentToken && allTradingTimesData === null && !isLoadingAllTradingTimes) {
         setIsLoadingAllTradingTimes(true);
+        logAutomatedTradingEvent('Fetching all trading times data (once)...');
         try {
-          const timesData = await getTradingTimes('today', currentToken); // getTradingTimes now takes (date, token)
-          setAllTradingTimesData(timesData);
-          logAutomatedTradingEvent("All trading times data fetched successfully.");
+          const timesData = await getTradingTimes('today', currentToken);
+          if (timesData && typeof timesData === 'object' && 'error' in timesData) {
+            setAllTradingTimesData({ error: timesData.error });
+            logAutomatedTradingEvent(`Error fetching all trading times: ${timesData.error}`);
+          } else if (timesData) {
+            setAllTradingTimesData(timesData);
+            logAutomatedTradingEvent('All trading times data fetched successfully.');
+          } else {
+            setAllTradingTimesData({ error: 'Failed to fetch all trading times (empty or unexpected response).' });
+            logAutomatedTradingEvent('Error fetching all trading times: Empty or unexpected response.');
+          }
         } catch (err: any) {
-          logAutomatedTradingEvent(`Error fetching all trading times: ${err.message || 'Unknown error'}`);
-          setAllTradingTimesData({ error: err.message || 'Failed to fetch all trading times.' });
+          const errorMsg = err.message || 'Exception while fetching all trading times.';
+          setAllTradingTimesData({ error: errorMsg });
+          logAutomatedTradingEvent(`Error fetching all trading times: ${errorMsg}`);
         } finally {
           setIsLoadingAllTradingTimes(false);
         }
       }
     };
 
-    fetchGlobalData();
-  }, [userInfo, selectedDerivAccountType, globalOfferingsData, isLoadingGlobalOfferings, toast, allTradingTimesData, isLoadingAllTradingTimes, logAutomatedTradingEvent]);
+    if (userInfo) { // Only run if userInfo is available
+      fetchInitialGlobalData();
+    }
+  }, [userInfo, selectedDerivAccountType, allTradingTimesData, globalOfferingsData, logAutomatedTradingEvent, toast]); // isLoadingGlobalOfferings and isLoadingAllTradingTimes removed from deps
 
   const currentBalance = useMemo(() => {
     if (authStatus === 'authenticated' && userInfo?.derivAccessToken) {
@@ -500,6 +522,7 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
                   times: symbolData.times,
                   events: symbolData.events,
                   feed_license: symbolData.feed_license,
+                  trading_days: symbolData.trading_days // Ensure trading_days is included
                 };
                 break;
               }
@@ -1035,7 +1058,7 @@ function mapDerivStatusToLocal(derivStatus?: DerivContractStatusData['status']):
                       times: symbolEntry.times,
                       events: symbolEntry.events,
                       feed_license: symbolEntry.feed_license,
-                      trading_days: symbolEntry.trading_days // Added trading_days
+                      trading_days: symbolEntry.trading_days // This should already be here from previous step, verifying
                     };
                     break;
                   }

--- a/src/contexts/auth-context.tsx
+++ b/src/contexts/auth-context.tsx
@@ -169,7 +169,36 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
       const authMethodFromProvider = nextAuthUser.provider === 'google' ? 'google' : (nextAuthUser.provider || 'nextauth') as AuthMethod;
 
+      // --- START: New logic for determining initial account type ---
+      let determinedInitialAccountType: 'demo' | 'real' | null = null;
+      if (typeof window !== 'undefined') {
+        const lastUsed = localStorage.getItem('lastUsedDerivAccountType') as 'demo' | 'real' | null;
+        if (lastUsed) {
+          if (lastUsed === 'demo' && nextAuthUser.derivDemoAccountId && nextAuthUser.derivDemoApiToken) {
+            determinedInitialAccountType = 'demo';
+          } else if (lastUsed === 'real' && nextAuthUser.derivRealAccountId && nextAuthUser.derivRealApiToken) {
+            determinedInitialAccountType = 'real';
+          }
+        }
+      }
+
+      if (!determinedInitialAccountType) {
+        if (nextAuthUser.derivDemoAccountId && nextAuthUser.derivDemoApiToken) {
+          determinedInitialAccountType = 'demo';
+        } else if (nextAuthUser.derivRealAccountId && nextAuthUser.derivRealApiToken) {
+          determinedInitialAccountType = 'real';
+        } else {
+          determinedInitialAccountType = nextAuthUser.selectedDerivAccountType as ('demo' | 'real' | null) || null;
+        }
+      }
+      console.log('[AuthContext] Determined initial account type:', determinedInitialAccountType);
+      // --- END: New logic for determining initial account type ---
+
       // Adapt session user to UserInfo, ensuring all Deriv fields are included
+      // Use determinedInitialAccountType to set the active token and account ID
+      const activeDerivToken = determinedInitialAccountType === 'real' ? nextAuthUser.derivRealApiToken : nextAuthUser.derivDemoApiToken;
+      const activeDerivAccountId = determinedInitialAccountType === 'real' ? nextAuthUser.derivRealAccountId : nextAuthUser.derivDemoAccountId;
+
       const adaptedUser: UserInfo = {
         id: nextAuthUser.id || '',
         name: nextAuthUser.name || nextAuthUser.email?.split('@')[0] || 'User',
@@ -177,22 +206,22 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         photoURL: nextAuthUser.image,
         authMethod: authMethodFromProvider,
         provider: nextAuthUser.provider,
-        derivAccessToken: nextAuthUser.derivAccessToken, // Ensure this is passed from session
-        derivAccountId: nextAuthUser.derivAccountId, // Main selected account ID
-        derivDemoAccountId: nextAuthUser.derivDemoAccountId,
-        derivRealAccountId: nextAuthUser.derivRealAccountId,
-        derivDemoBalance: nextAuthUser.derivDemoBalance,
-        derivRealBalance: nextAuthUser.derivRealBalance,
-        selectedDerivAccountType: nextAuthUser.selectedDerivAccountType as ('demo' | 'real' | null),
-        // Ensure derivApiToken is correctly mapped if it's a nested object in session
-        derivApiToken: nextAuthUser.derivApiToken || (nextAuthUser.derivAccessToken ? { access_token: nextAuthUser.derivAccessToken } : undefined),
+        // Core Deriv fields now reflect the determined initial account type
+        selectedDerivAccountType: determinedInitialAccountType,
+        derivAccessToken: activeDerivToken || null,
+        derivAccountId: activeDerivAccountId || null,
+        derivApiToken: activeDerivToken ? { access_token: activeDerivToken } : undefined,
 
-        // Newly added mappings:
-        derivDemoApiToken: nextAuthUser.derivDemoApiToken || null, // Ensure fallback to null if undefined
-        derivRealApiToken: nextAuthUser.derivRealApiToken || null, // Ensure fallback to null if undefined
+        // Specific account details remain available
+        derivDemoAccountId: nextAuthUser.derivDemoAccountId || null,
+        derivRealAccountId: nextAuthUser.derivRealAccountId || null,
+        derivDemoBalance: nextAuthUser.derivDemoBalance, // Keep as is from session
+        derivRealBalance: nextAuthUser.derivRealBalance, // Keep as is from session
+        derivDemoApiToken: nextAuthUser.derivDemoApiToken || null,
+        derivRealApiToken: nextAuthUser.derivRealApiToken || null,
       };
 
-      console.log('[AuthContext] Adapted user from NextAuth session:', JSON.stringify(adaptedUser, null, 2));
+      console.log('[AuthContext] Adapted user from NextAuth session with initial type selection:', JSON.stringify(adaptedUser, null, 2));
 
       // Check the flag HERE
       if (userJustSwitchedAccountTypeRef.current) {
@@ -291,32 +320,72 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setPaperBalance(newDemoBalance); // Reflect the other balance too
       }
        // Update userInfo state as well to keep it in sync with context for other consumers
-      setUserInfo(prevUserInfo => prevUserInfo ? ({
-        ...prevUserInfo,
-        selectedDerivAccountType: updatedSettings.selectedDerivAccountType,
-        derivDemoAccountId: updatedSettings.derivDemoAccountId,
-        derivRealAccountId: updatedSettings.derivRealAccountId,
-        derivDemoBalance: newDemoBalance,
-        derivRealBalance: newRealBalance,
-      }) : null);
+      setUserInfo(prevUserInfo => {
+        if (!prevUserInfo) return null;
+
+        const newSelectedType = updatedSettings.selectedDerivAccountType as 'demo' | 'real';
+        let newAccessToken = prevUserInfo.derivAccessToken;
+        let newAccountId = prevUserInfo.derivAccountId;
+
+        if (newSelectedType === 'demo') {
+          newAccessToken = prevUserInfo.derivDemoApiToken || undefined;
+          newAccountId = updatedSettings.derivDemoAccountId || null;
+        } else if (newSelectedType === 'real') {
+          newAccessToken = prevUserInfo.derivRealApiToken || undefined;
+          newAccountId = updatedSettings.derivRealAccountId || null;
+        }
+
+        return {
+          ...prevUserInfo,
+          selectedDerivAccountType: newSelectedType,
+          derivDemoAccountId: updatedSettings.derivDemoAccountId || null,
+          derivRealAccountId: updatedSettings.derivRealAccountId || null,
+          derivDemoBalance: newDemoBalance,
+          derivRealBalance: newRealBalance,
+          derivAccessToken: newAccessToken,
+          derivAccountId: newAccountId,
+          derivApiToken: newAccessToken ? { access_token: newAccessToken, token_type: prevUserInfo.derivApiToken?.token_type || 'bearer' } : undefined,
+        };
+      });
 
       // After local context states are updated, also update the NextAuth session
+      let activeTokenForSession = (nextSession?.user as any)?.derivAccessToken;
+      let activeAccountIdForSession = (nextSession?.user as any)?.derivAccountId;
+
+      if (updatedSettings.selectedDerivAccountType === 'demo') {
+          activeTokenForSession = (userInfo?.derivDemoApiToken) || undefined; // Use userInfo from context which should be updated by now, or nextSession's specific demo token
+          activeAccountIdForSession = updatedSettings.derivDemoAccountId || null;
+      } else if (updatedSettings.selectedDerivAccountType === 'real') {
+          activeTokenForSession = (userInfo?.derivRealApiToken) || undefined; // Use userInfo from context or nextSession's specific real token
+          activeAccountIdForSession = updatedSettings.derivRealAccountId || null;
+      }
+
+      // Store the newly selected type in localStorage
+      if (typeof window !== 'undefined' && updatedSettings.selectedDerivAccountType) {
+        localStorage.setItem('lastUsedDerivAccountType', updatedSettings.selectedDerivAccountType);
+      }
+
       await updateNextAuthSession({
         ...nextSession,
         user: {
-          ...nextSession?.user,
+          ...nextSession?.user, // Spread existing user fields
           selectedDerivAccountType: updatedSettings.selectedDerivAccountType,
           derivDemoAccountId: updatedSettings.derivDemoAccountId,
           derivRealAccountId: updatedSettings.derivRealAccountId,
           derivDemoBalance: newDemoBalance,
           derivRealBalance: newRealBalance,
+          // Update these to reflect the switch:
+          derivAccessToken: activeTokenForSession,
+          derivAccountId: activeAccountIdForSession,
+          // Carry over other important fields from existing session user
           id: nextSession?.user?.id,
           name: nextSession?.user?.name,
           email: nextSession?.user?.email,
           image: nextSession?.user?.image,
           provider: (nextSession?.user as any)?.provider,
-          derivAccessToken: (nextSession?.user as any)?.derivAccessToken,
-          derivAccountId: updatedSettings.selectedDerivAccountType === 'demo' ? updatedSettings.derivDemoAccountId : updatedSettings.derivRealAccountId,
+          // Also ensure specific tokens in session are passed through if they exist from initial login
+          derivDemoApiToken: (nextSession?.user as any)?.derivDemoApiToken,
+          derivRealApiToken: (nextSession?.user as any)?.derivRealApiToken,
         }
       });
       console.log('[AuthContext] NextAuth session update requested after account type switch.');


### PR DESCRIPTION
…count logic

This commit addresses several issues identified during testing:

1.  **Fix Multiple Fetches of `allTradingTimesData` (`src/app/page.tsx`):
    *   Refined the `useEffect` hook that fetches `allTradingTimesData` (and
        `globalOfferingsData`).
    *   The conditions for fetching (e.g., `allTradingTimesData === null`) and
        the dependency array have been adjusted to ensure this data is fetched
        only once when appropriate (e.g., after login and `userInfo` is available),
        preventing redundant API calls.

2.  **Address Demo Account State/Sync Issues after Switching:
    *   **`AuthContext` (`src/contexts/auth-context.tsx`):
        *   Enhanced `updateSelectedDerivAccountType` to ensure `userInfo.derivAccessToken`,
            `userInfo.derivAccountId`, and `userInfo.derivApiToken` are correctly updated
            to reflect the actively selected account type's (demo or real) credentials.
        *   General user details (name, email) are preserved during the switch.
        *   NextAuth session update logic was also aligned.
    *   **`DerivBalanceListener` in `src/app/page.tsx`:
        *   The `useEffect` hooks for demo and real account balance listeners now
            depend on `selectedDerivAccountType`.
        *   Logic was added to ensure only the listener for the currently active
            account type is initialized and running, and the other is closed.
            This should resolve demo balance sync issues after toggling.
        *   This is also expected to resolve the sidebar UI issue where Login/Signup
            buttons appeared for the demo account, as `userInfo` should now be
            consistently populated for the active account type.

3.  **Implement Default Account Selection Logic (`src/contexts/auth-context.tsx`):
    *   The context now attempts to load the 'lastUsedDerivAccountType' from
        `localStorage` upon initialization.
    *   If a valid last-used type and its credentials are found in the current session,
        it defaults to that type.
    *   Otherwise, it defaults to 'demo' if demo account credentials are available.
    *   If demo is not available, it defaults to 'real' if real account credentials
        are available.
    *   This provides a more user-friendly default account selection instead of
        always defaulting to real.
    *   `updateSelectedDerivAccountType` now saves the chosen type to `localStorage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling and switching between demo and real accounts, ensuring consistent account selection and synchronization across the dashboard.
  - Enhanced error handling and detailed status messages for trading times and market status displays.

- **Bug Fixes**
  - Resolved issues with redundant data fetching and inconsistent balance updates when switching account types.
  - Improved validation for AI auto-trading proposals, reducing invalid trade attempts and providing clearer user notifications.

- **Refactor**
  - Streamlined logic for account type selection and token management to improve reliability and efficiency.
  - Optimized use of cached trading times data to reduce unnecessary network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->